### PR TITLE
refresh test directory

### DIFF
--- a/tests/tests_setup.py
+++ b/tests/tests_setup.py
@@ -1,9 +1,11 @@
 import os
-from shutil import copyfile
+from shutil import copyfile,rmtree
 
 
 src = "./data/data_for_tests/updt_aln.fasta"
 dst = "./tests/output/test_runs/updt_aln.fasta"
+if os.path.exists("./tests/output/"):
+    rmtree("./tests/output/")
 os.mkdir("./tests/output/")
 os.mkdir("./tests/output/test_runs/")
 copyfile(src, dst)


### PR DESCRIPTION
Rather than erroring when `./tests/output/` exists, recursively delete the contents of `output`. This is useful, say, when one wants to pull a new name dump.

Feel freee to reject this. I just came across the erroring when performing:
```
python3 ./tests/tests_setup.py
```
more than once.